### PR TITLE
Refactor to use Alpine Linux (w/PyTorch wheel)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,10 @@ examples/moodbot/models/
 *~
 .dir-locals.el
 
+# IDEA IDEs (IntelliJ)
+*.iml
+.idea/
+
 *.DS_Store
 tests/executor_test_packages
 .pytype/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash libgcc libstdc++ libgfortran openblas
+    apk add --no-cache bash libstdc++ openblas
 
 FROM base as python_builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN python -m venv /opt/venv && \
   . /opt/venv/bin/activate && \
   pip install --no-cache-dir -U pip && \
   pip install --no-cache-dir wheel && \
-  poetry install --no-dev --no-root --no-interaction
+  poetry install --only main --no-root --no-interaction
 
 # install dependencies and build wheels
 # hadolint ignore=SC1091,DL3013

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk upgrade --no-cache && \
 
 FROM base as python_builder
 
-RUN apk add --no-cache curl gcc g++ gfortran pkgconfig cmake make musl-dev openblas-dev
+RUN apk add --no-cache curl g++ cmake make musl-dev openblas-dev
 
 # install poetry
 # keep this in sync with the version in pyproject.toml and Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN python -m venv /opt/venv \
 
 # install dependencies and build wheels
 # hadolint ignore=SC1091,DL3013
-RUN . /opt/venv/bin/activate && poetry build -f wheel -n \
+RUN . /opt/venv/bin/activate \
+  && poetry build -f wheel -n \
   && pip install --no-cache-dir --no-deps dist/*.whl \
   && mkdir /wheels \
   && poetry export -f requirements.txt --without-hashes --output /wheels/requirements.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,10 @@
-FROM ubuntu:22.10 as base
+FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
-RUN apt-get update -qq \
-    # Make sure that all security updates are installed
-    && apt-get dist-upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends \
-      python3 \
-      python3-venv \
-      python3-pip \
-      python3-dev \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 100 \
-   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 100
+RUN apk upgrade --no-cache && \
+    apk add --no-cache bash curl gcc make musl-dev
 
 FROM base as python_builder
-
-# hadolint ignore=DL3008
-RUN apt-get update -qq \
-   && apt-get install -y --no-install-recommends \
-    curl \
-    && apt-get autoremove -y
 
 # install poetry
 # keep this in sync with the version in pyproject.toml and Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash curl gcc g++ make musl-dev
+    apk add --no-cache bash curl gcc g++ gfortran make musl-dev
 
 FROM base as python_builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
-RUN apk upgrade --no-cache && \
-    apk add --no-cache bash libstdc++ openblas
+RUN apk upgrade --no-cache \
+    && apk add --no-cache bash libstdc++ openblas
 
 FROM base as python_builder
 
@@ -21,11 +21,11 @@ COPY . /app/
 WORKDIR /app
 
 # hadolint ignore=SC1091,DL3013
-RUN python -m venv /opt/venv && \
-  . /opt/venv/bin/activate && \
-  pip install --no-cache-dir -U pip && \
-  pip install --no-cache-dir wheel && \
-  poetry install --only main --no-root --no-interaction
+RUN python -m venv /opt/venv \
+  && . /opt/venv/bin/activate \
+  && pip install --no-cache-dir -U pip \
+  && pip install --no-cache-dir wheel \
+  && poetry install --only main --no-root --no-interaction
 
 # install dependencies and build wheels
 # hadolint ignore=SC1091,DL3013
@@ -60,7 +60,8 @@ COPY --from=python_builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # update permissions & change user
-RUN chgrp -R 0 /app && chmod -R g=u /app
+RUN chgrp -R 0 /app \
+    && chmod -R g=u /app
 USER 1001
 
 # change shell

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash
+    apk add --no-cache bash libgcc libstdc++ libgfortran openblas
 
 FROM base as python_builder
 
-RUN apk add --no-cache curl gcc g++ gfortran pkgconfig cmake make musl-dev
+RUN apk add --no-cache curl gcc g++ gfortran pkgconfig cmake make musl-dev openblas-dev
 
 # install poetry
 # keep this in sync with the version in pyproject.toml and Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash curl gcc g++ gfortran make musl-dev
+    apk add --no-cache bash curl gcc g++ gfortran pkgconfig cmake make musl-dev
 
 FROM base as python_builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash curl gcc g++ gfortran pkgconfig cmake make musl-dev
+    apk add --no-cache bash
 
 FROM base as python_builder
+
+RUN apk add --no-cache curl gcc g++ gfortran pkgconfig cmake make musl-dev
 
 # install poetry
 # keep this in sync with the version in pyproject.toml and Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-alpine as base
 
 # hadolint ignore=DL3005,DL3008
 RUN apk upgrade --no-cache && \
-    apk add --no-cache bash curl gcc make musl-dev
+    apk add --no-cache bash curl gcc g++ make musl-dev
 
 FROM base as python_builder
 


### PR DESCRIPTION
Refactor the image to use the `python:3.10-alpine` base image. This should help eliminate some security vulnerabilities.